### PR TITLE
Remove JSON loc. data related branching in keys request handler + update tests

### DIFF
--- a/builtin/app.py
+++ b/builtin/app.py
@@ -172,7 +172,7 @@ def healthcheck():
 @APP.route('{}/get_keys'.format(SERVICE_BASE_URL) if SERVICE_BASE_URL else '/get_keys', methods=['POST'])
 def get_keys():
     """
-    Do a lookup on posted location data.
+    Do a lookup on posted location data in CSV format
     """
     response = res_data = None
 
@@ -183,11 +183,8 @@ def get_keys():
         except KeyError:
             raise OasisException('Error: keys request is missing the "Content-Type" header')
         else:
-            if content_type not in [
-                HTTP_REQUEST_CONTENT_TYPE_CSV,
-                HTTP_REQUEST_CONTENT_TYPE_JSON
-            ]:
-                raise OasisException('Error: unsupported content type: "{}"'.format(content_type))
+            if content_type != HTTP_REQUEST_CONTENT_TYPE_CSV:
+                raise OasisException('Error: expected CSV content type but got "{}"'.format(content_type))
         logging.info('OK: {}'.format(content_type))
 
         logging.info('Checking whether the request content is compressed ...')
@@ -206,10 +203,7 @@ def get_keys():
 
         logging.info('Loading model exposures into Pandas dataframe ...')
         try:
-            loc_df = (
-                pd.read_csv(io.StringIO(loc_data), float_precision='high') if content_type == HTTP_REQUEST_CONTENT_TYPE_CSV
-                else pd.read_json(io.StringIO(loc_data))
-            )
+            loc_df = pd.read_csv(io.StringIO(loc_data), float_precision='high')
         except pd.errors.EmptyDataError as e:
             raise OasisException('Error: model exposures file is possibly empty or corrupted, could not load into Pandas dataframe: {}'.format(e))
 

--- a/custom/app.py
+++ b/custom/app.py
@@ -139,7 +139,7 @@ def healthcheck():
 @APP.route('{}/get_keys'.format(SERVICE_BASE_URL) if SERVICE_BASE_URL else '/get_keys', methods=['POST'])
 def get_keys():
     """
-    Do a lookup on posted location data.
+    Do a lookup on posted location data in CSV format
     """
     response = res_data = None
 
@@ -150,11 +150,8 @@ def get_keys():
         except KeyError:
             raise OasisException('Error: keys request is missing the "Content-Type" header')
         else:
-            if content_type not in [
-                HTTP_REQUEST_CONTENT_TYPE_CSV,
-                HTTP_REQUEST_CONTENT_TYPE_JSON
-            ]:
-                raise OasisException('Error: unsupported content type: "{}"'.format(content_type))
+            if content_type != HTTP_REQUEST_CONTENT_TYPE_CSV:
+                raise OasisException('Error: expected CSV content type but got "{}"'.format(content_type))
         logging.info('OK: {}'.format(content_type))
 
         logging.info('Checking whether the request content is compressed ...')
@@ -175,15 +172,9 @@ def get_keys():
         try:
             config.setdefault('LOC_PANDAS_DF_OBJECT_DTYPE', False)
             if config['LOC_PANDAS_DF_OBJECT_DTYPE']:
-                loc_df = (
-                    pd.read_csv(io.StringIO(loc_data), dtype='object', float_precision='high') if content_type == HTTP_REQUEST_CONTENT_TYPE_CSV
-                    else pd.read_json(io.StringIO(loc_data))
-                )
+                loc_df = pd.read_csv(io.StringIO(loc_data), dtype='object', float_precision='high')
             else:
-                loc_df = (
-                    pd.read_csv(io.StringIO(loc_data), float_precision='high') if content_type == HTTP_REQUEST_CONTENT_TYPE_CSV
-                    else pd.read_json(io.StringIO(loc_data))
-                )
+                loc_df = pd.read_csv(io.StringIO(loc_data), float_precision='high')
         except pd.errors.EmptyDataError as e:
             raise OasisException('Error: model exposures file is possibly empty or corrupted, could not load into Pandas dataframe: {}'.format(e))
 

--- a/tests/KeysServerTests.py
+++ b/tests/KeysServerTests.py
@@ -74,11 +74,11 @@ class KeysServerTests(unittest.TestCase):
                                     )
         # Optional config settings
         path_modelloc_csv  = TEST_CONFIG.get('SAMPLE_CSV_MODEL_EXPOSURES_FILE_PATH')
-        path_modelloc_json = TEST_CONFIG.get('SAMPLE_JSON_MODEL_EXPOSURES_FILE_PATH')
+        #path_modelloc_json = TEST_CONFIG.get('SAMPLE_JSON_MODEL_EXPOSURES_FILE_PATH')
         path_output_dir    = TEST_CONFIG.get('OUTPUT_FILE_DIR')
         self.skip_invalid  = TEST_CONFIG.get('SKIP_INVALID_TESTS')
         self.model_exposures_csv  = os.path.abspath(path_modelloc_csv) if path_modelloc_csv else None
-        self.model_exposures_json = os.path.abspath(path_modelloc_json) if path_modelloc_json else None
+        #self.model_exposures_json = os.path.abspath(path_modelloc_json) if path_modelloc_json else None
         self.store_output_dir     = os.path.abspath(path_output_dir) if path_output_dir else None
 
     def test_healthcheck(self):
@@ -153,93 +153,6 @@ class KeysServerTests(unittest.TestCase):
 
         data = None
         with io.open(self.model_exposures_csv, 'r', encoding='utf-8') as f:
-            data = u'{}'.format(f.read().strip())
-
-        # test for unrecognised content type header
-        headers = {
-            'Accept-Encoding': 'identity,deflate,gzip,compress',
-            'Content-Type': 'text/html; charset=utf-8',
-            'Content-Length': str(len(data))
-        }
-
-        get_keys_url = '{}/get_keys'.format(self.keys_server_baseurl)
-        res = requests.post(get_keys_url, headers=headers, data=data)
-
-        # Check that the response does not have a 200 status code
-        self.assertNotEqual(res.status_code, 200)
-
-        # test for missing content type header
-        headers = {
-            'Accept-Encoding': 'identity,deflate,gzip,compress',
-            'Content-Length': str(len(data))
-        }
-
-        get_keys_url = '{}/get_keys'.format(self.keys_server_baseurl)
-        res = requests.post(get_keys_url, headers=headers, data=data)
-
-        # Check that the response does not have a 200 status code
-        self.assertNotEqual(res.status_code, 200)
-
-
-    def test_keys_request_json(self):
-        if not self.model_exposures_json:
-            self.skipTest("JSON exposure file path not given")
-
-        data = None
-        with io.open(self.model_exposures_json, 'r', encoding='utf-8') as f:
-            data = u'{}'.format(f.read().strip())
-
-        headers = {
-            'Accept-Encoding': 'identity,deflate,gzip,compress',
-            'Content-Type': HTTP_REQUEST_CONTENT_TYPE_JSON,
-            'Content-Length': str(len(data))
-        }
-
-        get_keys_url = '{}/get_keys'.format(self.keys_server_baseurl)
-        res = requests.post(get_keys_url, headers=headers, data=data)
-
-        # Check that the response has a 200 status code
-        self.assertEqual(res.status_code, 200)
-
-        # Check that the response content is valid JSON and has valid content.
-        result_dict = None
-        try:
-            result_dict = json.loads(res.content)
-        except ValueError:
-            self.assertIsNotNone(result_dict)
-        else:
-            self.assertEqual(set(result_dict.keys()), {'status', 'items'})
-            self.assertTrue(isinstance(result_dict['status'], six.string_types))
-            self.assertEqual(result_dict['status'].lower(), 'success')
-            self.assertEqual(type(result_dict['items']), list)
-
-            items = result_dict['items']
-            successes = [it for it in items if it['status'].lower() == 'success']
-            failures = [it for it in items if it['status'].lower() != 'success']
-            successful_lookup_record_keys = {'id', 'peril_id', 'coverage_type', 'area_peril_id', 'vulnerability_id', 'status', 'message'}
-            failed_lookup_record_keys = {'id', 'peril_id', 'coverage_type', 'status', 'message'}
-
-            # Check that result dict keys are valid
-            if successes:
-                successes_valid = all(type(r) == dict and successful_lookup_record_keys <= set(r.keys()) for r in successes)
-                self.assertEqual(successes_valid, True)
-            if failures:
-                failures_valid = all(type(r) == dict and failed_lookup_record_keys <= set(r.keys()) for r in failures)
-                self.assertEqual(failures_valid, True)
-
-            # Store result dict for inspection
-            if self.store_output_dir:
-                file_name = 'request_json_result.json'
-                with io.open(os.path.join(self.store_output_dir, file_name) , 'w', encoding='utf-8') as f:
-                    f.write(json.dumps(result_dict, ensure_ascii=False, sort_keys=True, indent=4))
-
-
-    def test_keys_request_json__invalid_content_type(self):
-        if self.skip_invalid:
-            self.skipTest("Skip invalid flag set")
-
-        data = None
-        with io.open(self.model_exposures_json, 'r', encoding='utf-8') as f:
             data = u'{}'.format(f.read().strip())
 
         # test for unrecognised content type header


### PR DESCRIPTION
Removed branching in keys request handler (`get_keys`) related to processing JSON loc. data, and updated keys server tests module. So the existing `get_keys` request handler assumes CSV source file content.

Future support for JSON loc. data in the keys request is better enabled via a separate request handler/endpoint, which can be done very easily by copying the CSV keys request handler and making the appropriate modifications in the Pandas frame loading code, and the keys server tests can also be modified in the same way.